### PR TITLE
Support directives on type definition fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
 sudo: required
-lein: lein2
+lein: lein
 jdk:
   - oraclejdk8

--- a/resources/alumbra/GraphQLSchema.g4
+++ b/resources/alumbra/GraphQLSchema.g4
@@ -67,7 +67,7 @@ typeImplementsTypes
     ;
 
 typeDefinitionField
-    : fieldName arguments? directives? ':' typeDefinitionFieldType
+    : fieldName arguments? ':' typeDefinitionFieldType directives?
     ;
 
 typeDefinitionFieldType
@@ -83,7 +83,7 @@ arguments
     ;
 
 argument
-    : argumentName directives? ':' argumentType defaultValue?
+    : argumentName ':' argumentType defaultValue? directives?
     ;
 
 argumentName
@@ -183,7 +183,7 @@ directiveName
     ;
 
 directiveLocations
-    : directiveLocation+
+    : '|'? directiveLocation ( '|' directiveLocation )*
     ;
 
 directiveLocation

--- a/test/alumbra/parser/schema_test.clj
+++ b/test/alumbra/parser/schema_test.clj
@@ -30,7 +30,7 @@
 (deftest t-transform-collects-all-directive-locations
   (let [schema (schema/transform
                  (schema/parse
-                   "directive @skip on FIELD, INLINE_FRAGMENT, FRAGMENT_SPREAD"))]
+                   "directive @skip on FIELD | INLINE_FRAGMENT | FRAGMENT_SPREAD"))]
     (is (= #{:field :inline-fragment :fragment-spread}
            (set
              (get-in schema [:alumbra/directive-definitions
@@ -86,3 +86,20 @@
          "objectValue" :object
          "listValue"   :list
          "noValue"     nil)))
+
+; ## Directives on field definitions
+
+(deftest t-directives-allowed-on-field-definitions
+  (let [schema (schema/transform                            ;
+                 (schema/parse
+                    "type SomeType {
+                       field(arg: Int @example): String @example
+                     }"))]
+
+    (let [field-definition (-> schema :alumbra/type-definitions first :alumbra/field-definitions first)
+          directive-name #(-> % :alumbra/directives first :alumbra/directive-name)]
+      (is (= "example"
+             (directive-name field-definition)))
+
+      (is (= "example"
+             (-> field-definition :alumbra/argument-definitions first directive-name))))))


### PR DESCRIPTION
```graphql
directive @example on FIELD_DEFINITION | ARGUMENT_DEFINITION

type SomeType {
  field(arg: Int @example): String @example
}
```
-  Support directives on type definition fields
- Also add support for using | to separate directive locations
- Change .travis.yml to use `lein` instead of `lein2` (which is the default now, and whose symlink is broken, so we are really using lein 2.8.1)

I think this is consistent with the draft spec: http://facebook.github.io/graphql/draft/#sec-Type-System.Directives

This might be related to #4 